### PR TITLE
[WIP] as_vevent: use vDDDTypes instead of explicit date/datetime type

### DIFF
--- a/recurring_ical_events.py
+++ b/recurring_ical_events.py
@@ -17,7 +17,8 @@ from dateutil.rrule import rrulestr, rruleset, rrule, DAILY
 import dateutil.parser
 
 from collections import defaultdict
-from icalendar.prop import vDatetime, vDate
+from icalendar.prop import vDDDTypes
+
 
 def is_event(component):
     """Return whether a component is a calendar event."""
@@ -94,22 +95,16 @@ class UnfoldableCalendar:
                 self.source = source
                 self.start = start
                 self.stop = stop
-            
-            def _create_ical_entry_from(self, date_or_datetime):
-                """Choose the correct method for ical representation."""
-                if isinstance(date_or_datetime, datetime.datetime):
-                    return vDatetime(date_or_datetime)
-                return vDate(date_or_datetime)
 
             def as_vevent(self):
                 revent = self.source.copy()
-                revent["DTSTART"] = self._create_ical_entry_from(self.start)
-                revent["DTEND"] = self._create_ical_entry_from(self.stop)
+                revent["DTSTART"] = vDDDTypes(self.start)
+                revent["DTEND"] = vDDDTypes(self.stop)
                 return revent
-            
+
             def is_in_span(self, span_start, span_stop):
                 return time_span_contains_event(span_start, span_stop, self.start, self.stop)
-        
+
         def __init__(self, event, span_start):
             self.event = event
             self.span_start = span_start


### PR DESCRIPTION
This fixes a problem when using the `decoded` method.
E.g., `event.decoded('dtstart')` fails with an exception:

```
  File ".../.pyenv/lib/python3.7/site-packages/icalendar/cal.py", line 237, in decoded
    return self._decode(name, value)
  File ".../.pyenv/lib/python3.7/site-packages/icalendar/cal.py", line 220, in _decode
    decoded = types_factory.from_ical(name, value)
  File ".../.pyenv/lib/python3.7/site-packages/icalendar/prop.py", line 1042, in from_ical
    decoded = type_class.from_ical(value)
  File ".../.pyenv/lib/python3.7/site-packages/icalendar/prop.py", line 334, in from_ical
    u = ical.upper()
```

This is due to a type inconsistency between the event created by this
package and the type that `icalendar` expects.

Another (ugly) workaround for this problem (if this patch was not
applied) would be to convert the event to ical and parse it back using
`icalendar`, which repairs the dtstart type inconsistency as well (e.g.,
something like `event = icalendar.Calendar.from_ical(event.to_ical())``