### PR TITLE
add pip list to show all package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - rm -rf build
   # show the versions
   - python setup.py --version
-  - pytest --version
+  - pip list
   - echo "Package version $PACKAGE_VERSION with possible tag name $TAG_NAME"
 script:
   - pytest


### PR DESCRIPTION
This adds the pip listing. The requirements do not fix versions and the tests should be reproducible and easily diffing.