### PR TITLE
Add ability to keep recurrence attributes on event copies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,9 @@ However, these attributes may differ from the source event:
 
 * DTSTART which is the start of the event instance.
 * DTEND which is the end of the event instance.
-* RDATE, EXDATE, RRULE are the rules to create event repetitions. They are **not** included in repeated events, see `Issue 23 <https://github.com/niccokunzmann/python-recurring-ical-events/issues/23>`_.
+* RDATE, EXDATE, RRULE are the rules to create event repetitions.
+  They are **not** included in repeated events, see `Issue 23 <https://github.com/niccokunzmann/python-recurring-ical-events/issues/23>`_.
+  To change this, use ``of(calendar, keep_recurrence_attributes=True)``.
 
 Development
 -----------

--- a/test/test_keep_recurrence_attributes.py
+++ b/test/test_keep_recurrence_attributes.py
@@ -7,7 +7,7 @@ from icalendar import Calendar
 
 HERE = os.path.dirname(__name__) or "test"
 CALENDARS_FOLDER = os.path.join(HERE, "calendars")
-calendar_path = os.path.join(CALENDARS_FOLDER, "one-day-event-repeat-every-day.ics")
+calendar_path = os.path.join(CALENDARS_FOLDER, "rdate.ics")
 
 
 def test_keep_recurrence_attributes_default(calendars):
@@ -21,6 +21,8 @@ def test_keep_recurrence_attributes_default(calendars):
     events = of(calendar).between(today, one_year_ahead)
     for event in events:
         assert event.get("RRULE", False) is False
+        assert event.get("RDATE", False) is False
+        assert event.get("EXDATE", False) is False
 
 
 def test_keep_recurrence_attributes_false(calendars):
@@ -34,6 +36,8 @@ def test_keep_recurrence_attributes_false(calendars):
     events = of(calendar, keep_recurrence_attributes=False).between(today, one_year_ahead)
     for event in events:
         assert event.get("RRULE", False) is False
+        assert event.get("RDATE", False) is False
+        assert event.get("EXDATE", False) is False
 
 
 def test_keep_recurrence_attributes_true(calendars):
@@ -47,3 +51,5 @@ def test_keep_recurrence_attributes_true(calendars):
     events = of(calendar, keep_recurrence_attributes=True).between(today, one_year_ahead)
     for event in events:
         assert event.get("RRULE", False) is not False
+        assert event.get("RDATE", False) is not False
+        assert event.get("EXDATE", False) is not False

--- a/test/test_keep_recurrence_attributes.py
+++ b/test/test_keep_recurrence_attributes.py
@@ -1,0 +1,36 @@
+"""This file tests the `keep_recurrence_attributes` argument of `of` works as expected."""
+import os
+
+from datetime import datetime
+from recurring_ical_events import of
+from icalendar import Calendar
+
+HERE = os.path.dirname(__name__) or "test"
+CALENDARS_FOLDER = os.path.join(HERE, "calendars")
+calendar_path = os.path.join(CALENDARS_FOLDER, "one-day-event-repeat-every-day.ics")
+
+
+def test_keep_recurrence_attributes_default(calendars):
+    with open(calendar_path, "rb") as file:
+        content = file.read()
+
+    calendar = Calendar.from_ical(content)
+    today = datetime.today()
+    one_year_ahead = today.replace(year=today.year + 1)
+
+    events = of(calendar).between(today, one_year_ahead)
+    for event in events:
+        assert event.get("RRULE", False) is False
+
+
+def test_keep_recurrence_attributes_true(calendars):
+    with open(calendar_path, "rb") as file:
+        content = file.read()
+
+    calendar = Calendar.from_ical(content)
+    today = datetime.today()
+    one_year_ahead = today.replace(year=today.year + 1)
+
+    events = of(calendar, keep_recurrence_attributes=True).between(today, one_year_ahead)
+    for event in events:
+        assert event.get("RRULE", False) is not False

--- a/test/test_keep_recurrence_attributes.py
+++ b/test/test_keep_recurrence_attributes.py
@@ -23,6 +23,19 @@ def test_keep_recurrence_attributes_default(calendars):
         assert event.get("RRULE", False) is False
 
 
+def test_keep_recurrence_attributes_false(calendars):
+    with open(calendar_path, "rb") as file:
+        content = file.read()
+
+    calendar = Calendar.from_ical(content)
+    today = datetime.today()
+    one_year_ahead = today.replace(year=today.year + 1)
+
+    events = of(calendar, keep_recurrence_attributes=False).between(today, one_year_ahead)
+    for event in events:
+        assert event.get("RRULE", False) is False
+
+
 def test_keep_recurrence_attributes_true(calendars):
     with open(calendar_path, "rb") as file:
         content = file.read()


### PR DESCRIPTION
Add an argument `keep_recurrence_attributes` to the `of()` function in order to manually undo the stripping of `RRULE`, `RDATE`, and `EXDATE` attributes from each event copy.

### Changes

* Add argument to relevant functions
* Add tests
* Update readme

### Why?

I agree with the reason these were stripped in the first place (https://github.com/niccokunzmann/python-recurring-ical-events/pull/24). However, for my use case, I want to keep these attributes on each event so I can differentiate between normal events and recurring events. Without these attributes, all events look the same. For example, when displaying events to the user, I want to display the recurrence rules as well.

### Alternative

An alternative would be to implement grouping. I.e, return events as a dict, grouped by the recurrence, or the source event they were created from (with a special group for non-recurring events). However I felt that was overly complicated and I went for the simpler solution.