### PR TITLE
Remove pytz dependency

### DIFF
--- a/recurring_ical_events.py
+++ b/recurring_ical_events.py
@@ -32,7 +32,7 @@ def convert_to_datetime(date, tzinfo):
     if isinstance(date, datetime.datetime):
         if date.tzinfo is None:
             if tzinfo is not None:
-                return date.astimezone(tzinfo)
+                return date.replace(tzinfo=tzinfo)
         elif tzinfo is None:
             return date.replace(tzinfo=None)
         return date

--- a/recurring_ical_events.py
+++ b/recurring_ical_events.py
@@ -19,20 +19,6 @@ import sys
 from collections import defaultdict
 from icalendar.prop import vDDDTypes
 
-if sys.version_info[0] == 2:
-    _EPOCH = datetime.datetime.utcfromtimestamp(0)
-    _EPOCH_TZINFO = _EPOCH.astimezone(datetime.timezone.utc)
-    def timestamp(dt):
-        """Return the time stamp of a datetime"""
-        # from https://stackoverflow.com/a/35337826
-        if dt.tzinfo:
-            return (dt - _EPOCH_TZINFO).total_seconds()
-        return (dt - _EPOCH).total_seconds()
-else:
-    def timestamp(dt):
-        """Return the time stamp of a datetime"""
-        return dt.timestamp()
-
 def is_event(component):
     """Return whether a component is a calendar event."""
     return isinstance(component, icalendar.cal.Event)
@@ -222,7 +208,7 @@ class RepeatedEvent:
         compare it with exdates.
         """
         if isinstance(dt, datetime.datetime):
-            return timestamp(dt)
+            return dt.timestamp()
         return dt
 
     def within_days(self, span_start, span_stop):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 icalendar
-pytz
 python-dateutil>=2.8.1

--- a/setup.py
+++ b/setup.py
@@ -127,8 +127,6 @@ SETUPTOOLS_METADATA = dict(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         development_state


### PR DESCRIPTION
This changes the types of timezones that are accepted by the library, from pytz instances to those that satisfy PEP-495.

On Python 3.9 and above, the `zoneinfo` built-in module provides a compatible class.  On Python 3.6 and above, `backports.zoneinfo` can be used in its place, or `dateutil` provides its own implementation.  Users can also continue to use `pytz` timezones by modifying their code to wrap them with `pytz_deprecation_shim` (this change could be extended
to apply this shim within the library itself, avoiding the need for users to change their code).

Python versions below 3.6 will no longer be supported (due to the use of `datetime.astimezone()`), though the major Linux distributions all carry 3.6+, and upstream support for older versions has long since ended.

Fixes #57 -- see there for context on this PR.