### PR TITLE
Use proper SPDX license ID

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ METADATA = dict(
     author=__author__,
     author_email='niccokunzmann@rambler.ru',
     description='A Python module which repeats ICalendar events by RRULE, RDATE and EXDATE.',
-    license='LGPLv3+',
+    license='LGPL-3.0-or-later',
     url='https://github.com/niccokunzmann/python-recurring-ical-events',
     keywords='icalendar',
 )


### PR DESCRIPTION
Hey,

my dependencyscanner does not pick up the license you are using. Perhaps it would be OK for you to use the SPDX identifier?

A list of all identifiers can be found here:
https://spdx.org/licenses/

Thanks for your work
Max