### PR TITLE
test how to extend recurring ical events

### DIFF
--- a/recurring_ical_events.py
+++ b/recurring_ical_events.py
@@ -909,6 +909,19 @@ class Occurrence:
         return self.id == other.id
 
 
+class CollectComponents(ABC):
+    """Class to collect components from a calendar."""
+
+    @abstractmethod
+    def collect_components(
+        self, source: Component, suppress_errors: tuple[Exception]
+    ) -> Sequence[Series]:
+        """Collect all components from the source component.
+
+        suppress_errors - a list of errors that should be suppressed.
+            A Series of events with such an error is removed from all results.
+        """
+
 class CalendarQuery:
     """A calendar that can unfold its events at a certain time.
 
@@ -1142,4 +1155,5 @@ __all__ = [
     "Time",
     "RecurrenceID",
     "RecurrenceIDs",
+    "CollectComponents",
 ]

--- a/test/test_extend_classes.py
+++ b/test/test_extend_classes.py
@@ -1,0 +1,38 @@
+"""This tests extneding and modifying the behaviour of recurring ical events."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+from recurring_ical_events import (
+    CollectComponents,
+    EventAdapter,
+    JournalAdapter,
+    Series,
+    TodoAdapter,
+    of,
+)
+
+if TYPE_CHECKING:
+    from icalendar.cal import Component
+
+
+class CollectOneUIDEvent(CollectComponents):
+    """Collect only one UID."""
+
+    def __init__(self, uid:str) -> None:
+        self.uid = uid
+
+    def collect_components(self, source: Component, suppress_errors: tuple[Exception]) -> Sequence[Series]:
+        return [
+            series
+            for adapter in [EventAdapter, JournalAdapter, TodoAdapter]
+            for series in adapter.collect_components(source, suppress_errors)
+            if series.uid == self.uid
+        ]
+
+
+def test_collect_only_one_uid(calendars):
+    """Test that only one UID is used."""
+    one_uid = CollectOneUIDEvent("4mm2ak3in2j3pllqdk1ubtbp9p@google.com")
+    query = of(calendars.raw.machbar_16_feb_2019, components=[one_uid])
+    assert query.count() == 1


### PR DESCRIPTION
This shows how to extend every aspect of the calculation.

Contributes to #133.