### PR TITLE
Add icalendar-events-cli to 'Related Projects' list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -830,8 +830,10 @@ Related Projects
 - `icspy <https://icspy.readthedocs.io/>`_ - to create your own calendar events
 - `pyICSParser <https://pypi.org/project/pyICSParser/>`_ - parse icalendar files and return event times (`GitHub <https://github.com/oberron/pyICSParser>`__)
 - `ics-query`_ - a **command line** impementation of ``recurring-ical-events``
+- `icalendar-events-cli`_ - another **command line** impementation of ``recurring-ical-events``
 
 .. _`ics-query`: https://github.com/niccokunzmann/ics-query#readme
+.. _`icalendar-events-cli`: https://github.com/waldbaer/icalendar-events-cli#readme
 
 Media
 -----


### PR DESCRIPTION
For 2 years I used an initial hacky  version of a small command line wrapper downloading an ICS calendar from an HTTP URL and then parsing / querying it with the famous recurring-ical-events library. Everything integrated in my Node-RED home automation.

Now it was time to polish it and publishing it to PyPI.

I would be happy if you could add it to the list of projects using the library.

Thanks for all your efforts!