### PR TITLE
changed license identifier to correspond with license file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "recurring-ical-events"
-license = "GPL-3.0-or-later"
+license = "LGPL-3.0-or-later"
 license-files = ["LICENSE"]
 keywords = ["icalendar", "calendar", "ics", "rfc5545", "scheduling", "events", "todo", "journal", "alarm"]
 dynamic = ["urls", "version"]


### PR DESCRIPTION
I noticed that the license identifier in `pyproject.toml` does not correspond with the license file.
Looks like a typo when the syntax was changed in [#229](https://github.com/niccokunzmann/python-recurring-ical-events/pull/229)