### PR TITLE
Document Sphinx type aliases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,15 +162,7 @@ github_repository = "python-recurring-ical-events"
 # from https://github.com/sphinx-doc/sphinx/issues/10785
 nitpick_ignore = [
     # ignore for now
-    ("py:class", "recurring_ical_events.types.Time"),
-    ("py:class", "recurring_ical_events.types.UID"),
-    ("py:class", "recurring_ical_events.types.RecurrenceIDs"),
-    ("py:class", "Time"),
-    ("py:class", "UID"),
     ("py:class", "RecurrenceID"),
-    ("py:class", "TypeAliasForwardRef"),
-    # /home/nicco/recurring-ical-events/recurring_ical_events/__init__.py:docstring of recurring_ical_events.OccurrenceID.uid:1: WARNING: duplicate object description of recurring_ical_events.OccurrenceID.uid, other instance in reference/api, use :no-index: for one of them
-    ("py:obj", "recurring_ical_events.OccurrenceID.uid"),
 ]
 
 # make title smaller

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -100,11 +100,33 @@ These are the pages returned by the query.
 
 .. automodule:: recurring_ical_events.types
     :members:
+```
 
+## Type aliases
+
+```{eval-rst}
+.. autodata:: recurring_ical_events.types.Time
+    :no-value:
+    :no-index:
+
+.. autodata:: recurring_ical_events.types.UID
+    :no-value:
+    :no-index:
+
+.. autodata:: recurring_ical_events.types.RecurrenceIDs
+    :no-value:
+    :no-index:
+```
+
+## Occurrence identifiers
+
+```{eval-rst}
 .. autoclass:: recurring_ical_events.OccurrenceID
+
+  .. autoattribute:: uid
+     :no-index:
 
   .. automethod:: to_string
   .. automethod:: from_string
   .. automethod:: from_occurrence
-
 ```


### PR DESCRIPTION
## Summary
- make the public `Time`, `UID`, and `RecurrenceIDs` aliases explicit in the API reference
- document `OccurrenceID.uid` in the occurrence identifier section
- remove stale nitpick ignores for the now-documented symbols and `TypeAliasForwardRef`

## Verification
- `git diff --check`
- `python3 -m py_compile recurring_ical_events/*.py`
- `/tmp/recurring-docs-venv2/bin/sphinx-build -W -b html --fresh-env --write-all docs /tmp/recurring-ical-events-docs-check-pinned`

Note: the pinned docs requirements currently conflict on `astroid==4.0.2` vs `sphinx-autoapi==3.6.1`; for the local docs check I used the pinned docs requirements with only that conflicting astroid pin excluded.

Closes #242

Note: prepared transparently with AI assistance and manually verified before submission.