### PR TITLE
Improve docs navigation and section TOCs

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -31,6 +31,16 @@ For style and formatting, please consult the [documentation reference section].
 
 [documentation reference section]: ../reference/documentation
 
+## Community navigation
+
+```{toctree}
+:maxdepth: 1
+:caption: Community
+
+media
+maintenance
+```
+
 ## Setup to develop
 
 This section informs you how to work on this project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,9 +39,9 @@ Information about usage.
 
 ```{toctree}
 :maxdepth: 2
+:caption: User guide
 
 user-guide/index
-user-guide/examples
 ```
 
 
@@ -51,16 +51,9 @@ Information about contributing.
 
 ```{toctree}
 :maxdepth: 2
+:caption: Community
 
 community/index
-community/media
-community/maintenance
-```
-
-```{toctree}
-:maxdepth: 1
-
-security_policy
 ```
 
 ## Reference
@@ -69,20 +62,15 @@ This is reference material for information.
 
 ```{toctree}
 :maxdepth: 2
+:caption: Reference
 
-reference/api
-reference/architecture
-reference/compatibility
-reference/dependencies
-reference/documentation
-reference/related-projects
-reference/research
-
+reference/index
 ```
 
 ```{toctree}
 :maxdepth: 1
+:caption: Project information
 
 changelog
-reference/license
+security_policy
 ```

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -57,7 +57,7 @@ myst:
 * ✅ [RDATE](https://www.kanzaki.com/docs/ical/rdate.html) (DONE)
 * ✅ [DURATION](https://www.kanzaki.com/docs/ical/duration.html) (DONE)
 * ✅ [EXDATE](https://www.kanzaki.com/docs/ical/exdate.html) (DONE)
-* ✅ [X-WR-TIMEZONE] compatibilty (DONE)
+* ✅ [X-WR-TIMEZONE] compatibility (DONE)
 * ✅ RECURRENCE-ID with THISANDFUTURE - modify all future events (DONE)
 
 ## Missing features

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,34 @@
+---
+myst:
+  html_meta:
+    "description lang=en": |
+      Reference material for writing documentation and understanding the library.
+---
+
+# Documentation reference
+
+This section collects the API reference and supporting project notes.
+
+## API and behavior
+
+```{toctree}
+:maxdepth: 2
+:caption: API and behavior
+
+api
+architecture
+compatibility
+dependencies
+```
+
+## Project information
+
+```{toctree}
+:maxdepth: 2
+:caption: Project information
+
+documentation
+related-projects
+research
+license
+```

--- a/docs/reference/related-projects.rst
+++ b/docs/reference/related-projects.rst
@@ -7,8 +7,8 @@ Related Projects
 - `Open Web Calendar <https://github.com/niccokunzmann/open-web-calendar>`_ - a web calendar to embed into websites which uses this library
 - `icspy <https://icspy.readthedocs.io/>`_ - to create your own calendar events
 - `pyICSParser <https://pypi.org/project/pyICSParser/>`_ - parse icalendar files and return event times (`GitHub <https://github.com/oberron/pyICSParser>`__)
-- `ics-query`_ - a **command line** impementation of ``recurring-ical-events``
-- `icalendar-events-cli`_ - another **command line** impementation of ``recurring-ical-events``
+- `ics-query`_ - a **command line** implementation of ``recurring-ical-events``
+- `icalendar-events-cli`_ - another **command line** implementation of ``recurring-ical-events``
 - `caldav`_ - the python caldav client library
 - `plann`_ - a **command line** caldav client
 - `ics_calendar`_ - Provides a component for ICS (icalendar) calendars for `Home Assistant`_

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -68,3 +68,12 @@ We have a comprehensive list of **[examples]** to get you started.
 
 [icalendar]: https://icalendar.readthedocs.io
 [examples]: examples.rst
+
+## User guide navigation
+
+```{toctree}
+:maxdepth: 1
+:caption: User guide
+
+examples
+```


### PR DESCRIPTION
Add section toctrees for the user guide, community, and reference docs, and tighten a few wording issues while restructuring the docs navigation.

Closes #240.

Validation:
- tox -e docs
- git diff --check