### PR TITLE
Document RFC impact on occurrence calculation

### DIFF
--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -21,6 +21,10 @@ myst:
 
 {rfc}`5545` is fully supported.
 
+This is the core specification for the occurrences that this library computes:
+``VEVENT``, ``VTODO``, ``VJOURNAL``, ``VALARM``, ``RRULE``, ``RDATE``,
+``EXDATE``, ``RECURRENCE-ID``, and the alarm ``TRIGGER`` rules.
+
 ### RFC 7529 - Non-Gregorian Recurrence Rules
 
 ![RFC 7529 is not implemented](https://img.shields.io/badge/RFC_7529-todo-red)
@@ -32,6 +36,39 @@ myst:
 ![RFC 7953 is not implemented](https://img.shields.io/badge/RFC_7953-todo-red)
 
 {rfc}`7953` is not implemented.
+
+### RFC 9074 - VALARM Extensions for iCalendar
+
+![RFC 9074 is partially supported](https://img.shields.io/badge/RFC_9074-partial-yellow)
+
+{rfc}`9074` updates ``VALARM`` components.
+This library computes alarm occurrences from the ``TRIGGER``, ``REPEAT``, and
+``DURATION`` rules defined for alarms by {rfc}`5545`.
+The extra alarm metadata and interoperability features from {rfc}`9074`, such
+as ``UID``, ``ACKNOWLEDGED``, ``RELATED-TO``, and ``PROXIMITY``, do not change
+which occurrences are returned.
+
+## RFCs and occurrence calculation
+
+The library computes when supported calendar components occur.
+RFCs that change recurrence rules, component time spans, or alarm trigger times
+can affect this computation.
+RFCs that add descriptive metadata, relationship metadata, or scheduling
+protocol semantics can be present in iCalendar data, but they do not by
+themselves change the result of ``at()``, ``between()``, ``after()``, or
+``all()``.
+
+| RFC | Scope for this library |
+| --- | --- |
+| {rfc}`5545` | Core recurrence, exception, component, and alarm trigger rules. |
+| {rfc}`5546` | iTIP scheduling messages; not used to expand occurrence times. |
+| {rfc}`6868` | Parameter value encoding; handled before recurrence logic. |
+| {rfc}`7529` | Non-Gregorian ``RRULE`` support; affects recurrence calculation but is not implemented. |
+| {rfc}`7953` | ``VAVAILABILITY`` and availability calculation; outside the queried components. |
+| {rfc}`7986` | New descriptive properties; no direct effect on occurrence times. |
+| {rfc}`9073` | Event publishing properties, components, and structured data; no direct effect on occurrence times. |
+| {rfc}`9074` | Alarm extensions; base alarm trigger calculation is supported through {rfc}`5545`, while the added metadata does not change occurrence times. |
+| {rfc}`9253` | Relationship and linking properties; not used to expand or filter occurrences. |
 
 ## Other Specifications
 


### PR DESCRIPTION
## Summary
- add RFC 9074 VALARM compatibility notes
- document which RFC 5545 updates affect occurrence calculation and which are metadata/protocol-only for this library
- clarify that RFC 5545 remains the core source for supported component, recurrence, exception, and alarm trigger rules

Closes #239

## Verification
- git diff --check
- venv/bin/sphinx-build -b html --fresh-env --write-all docs docs/_build/html

Note: `tox` is not installed locally, so I used the bundled Python 3.12 runtime to run the Sphinx build directly.