### PR TITLE
Handle relative alarms for all-day events

### DIFF
--- a/recurring_ical_events/series/alarm.py
+++ b/recurring_ical_events/series/alarm.py
@@ -14,6 +14,13 @@ from recurring_ical_events.types import Time
 from recurring_ical_events.util import convert_to_datetime
 
 
+def _as_datetime(value: Time) -> datetime.datetime:
+    """Return date values as midnight datetimes for alarm arithmetic."""
+    if isinstance(value, datetime.datetime):
+        return value
+    return datetime.datetime.combine(value, datetime.time())
+
+
 class AbsoluteAlarmSeries:
     """A series of absolute alarms."""
 
@@ -96,7 +103,7 @@ class AlarmSeriesRelativeToStart:
         self, offset: datetime.timedelta, alarm: Alarm, parent: Occurrence
     ) -> Occurrence:
         """Create a new occurrence."""
-        return AlarmOccurrence(offset + parent.start, alarm, parent)
+        return AlarmOccurrence(_as_datetime(parent.start) + offset, alarm, parent)
 
     def __repr__(self) -> str:
         """repr()"""
@@ -122,7 +129,7 @@ class AlarmSeriesRelativeToEnd(AlarmSeriesRelativeToStart):
         self, offset: datetime.timedelta, alarm: Alarm, parent: Occurrence
     ) -> Occurrence:
         """Create a new occurrence."""
-        return AlarmOccurrence(offset + parent.end, alarm, parent)
+        return AlarmOccurrence(_as_datetime(parent.end) + offset, alarm, parent)
 
 
 __all__ = [

--- a/recurring_ical_events/test/test_issue_186_alarms.py
+++ b/recurring_ical_events/test/test_issue_186_alarms.py
@@ -9,6 +9,8 @@ from datetime import datetime, timedelta, timezone
 import icalendar
 import pytest
 
+import recurring_ical_events
+
 
 @pytest.mark.parametrize(
     ("when", "count"),
@@ -213,6 +215,54 @@ def test_alarm_without_trigger_is_ignored_as_invalid(alarms):
         description = a.alarms.times[0].alarm["DESCRIPTION"]
         assert description in ("correct trigger", "absolute trigger")
     assert len(e) == 2
+
+
+def test_relative_alarm_before_date_start():
+    """Relative alarms for all-day events keep their time of day."""
+    calendar = icalendar.Calendar.from_ical(
+        b"""BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:date-start-alarm
+DTSTART;VALUE=DATE:20240729
+DTEND;VALUE=DATE:20240730
+SUMMARY:all-day event
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:-PT10M
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+"""
+    )
+
+    events = list(recurring_ical_events.of(calendar, components=["VALARM"]).all())
+
+    assert len(events) == 1
+    assert events[0].alarms.times[0].trigger == datetime(2024, 7, 28, 23, 50)
+
+
+def test_relative_alarm_after_date_end():
+    """Relative alarms from all-day event ends are datetimes."""
+    calendar = icalendar.Calendar.from_ical(
+        b"""BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:date-end-alarm
+DTSTART;VALUE=DATE:20240729
+DTEND;VALUE=DATE:20240730
+SUMMARY:all-day event
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;RELATED=END:PT15M
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+"""
+    )
+
+    events = list(recurring_ical_events.of(calendar, components=["VALARM"]).all())
+
+    assert len(events) == 1
+    assert events[0].alarms.times[0].trigger == datetime(2024, 7, 30, 0, 15)
 
 
 def test_event_is_not_modified_with_2_alarms(alarms):


### PR DESCRIPTION
## Summary
- convert all-day event date starts/ends to midnight datetimes before applying relative VALARM offsets
- keep relative alarm trigger times precise instead of producing date-only triggers
- add regression coverage for alarms before an all-day start and after an all-day end

Fixes #234

## Verification
- python snippet against recurring_ical_events/test/calendars/issue_173_only_modifications_error.ics no longer raises
- .venv/bin/python -m pytest recurring_ical_events/test/test_issue_186_alarms.py
- .venv/bin/python -m ruff check recurring_ical_events/series/alarm.py recurring_ical_events/test/test_issue_186_alarms.py
- git diff --check